### PR TITLE
Close #4 Add asynchronous http calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ statful = StatfulClient.new(config)
 
 ### Logger configuration
 
-Creates a simple client configuration and adds your favourite logger to the client. 
+Creates a simple client configuration and adds your favourite logger to the client.
 
 **Just assure that logger object supports, at least, warn, debug and error methods**.
 
@@ -209,7 +209,8 @@ The custom options that can be set on config param are detailed below.
 | _logger_ | Defines logger object. | `Object` | **none** | **NO** |
 | _tags_ | Defines the global tags. | `Hash` | `{}` | **NO** |
 | _sample_rate_ | Defines the rate sampling. **Should be a number between [1, 100]**. | `Integer` | `100` | **NO** |
-| _flush_size_ | Defines the maximum buffer size before performing a flush. | `Integer` | `100` | **NO** |
+| _flush_size_ | Defines the maximum buffer size before performing a flush. | `Integer` | `5` | **NO** |
+| _thread_pool_size_ | Defines the maximum thread pool size. | `Integer` | `5` | **NO** |
 | _namespace_ | Defines the global namespace. | `String` | `application` | **NO** |
 | _default_ | Object to set methods options. | `Object` | `{}` | **NO** |
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ class FakeUDPSocket
   attr_accessor :buffer
 
   def initialize
-    @buffer = []
+    @buffer = Queue.new
   end
 
   def send(message)
@@ -48,7 +48,7 @@ class FakeUDPSocket
   end
 
   def clear
-    @buffer = []
+    @buffer = Queue.new
   end
 
   def to_s

--- a/spec/statful_spec.rb
+++ b/spec/statful_spec.rb
@@ -49,7 +49,7 @@ describe StatfulClient do
     end
 
     it 'should create an empty buffer' do
-      @statful.buffer.must_equal []
+      @statful.buffer.size.must_equal 0
     end
 
     it 'should raise ArgumentError if transport is missing' do
@@ -141,7 +141,7 @@ describe StatfulClient do
         @statful.buffer.clear
         @statful.timer('test_dryrun', 500)
         @log.string.must_match(/Flushing metrics: application.timer.test_dryrun,tag=test_tag,unit=ms,app=test_app 500 \d+ avg,p90,count,10 100/)
-        @statful.udp_socket.buffer.must_equal []
+        @statful.udp_socket.buffer.size.must_equal 0
         @statful.buffer.size.must_equal 0
       end
     end

--- a/statful-client.gemspec
+++ b/statful-client.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name          = 'statful-client'
-  s.version       =  '2.0.1'
+  s.version       =  '2.1.0'
   s.summary       = 'Statful Ruby Client'
   s.description   = 'Statful Ruby Client (https://www.statful.com)'
   s.license       = 'MIT'
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.files         = Dir['lib/**/*.rb']
   s.require_paths = ['lib']
+
+  s.add_runtime_dependency 'concurrent-ruby-ext'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'yard'


### PR DESCRIPTION
HTTP transport is now dealt by a thread pool, enabling asynchronous calls.

Signed-off-by: Tiago Pires tiago.pires@mindera.com
